### PR TITLE
feat: add scrubber support for hiding sensitive data

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,26 @@ tracy_blue_screen:
             - '%kernel.cache_dir%'
             # plus paths set in BlueScreen instance used (/vendor)
 
+        # Service ID of a callable(string $key, mixed $value, ?string $class): bool
+        # that returns true for sensitive data to hide (passwords, tokens, API keys, etc.)
+        scrubber: ~
+
+```
+
+Example scrubber implementation:
+
+```php
+namespace App\Tracy;
+
+use Cdn77\TracyBlueScreenBundle\BlueScreen\TracyScrubber;
+
+final class SensitiveDataScrubber implements TracyScrubber
+{
+    public function __invoke(string $key, mixed $value, string|null $class): bool
+    {
+        return preg_match('/(PASSWORD|SECRET|TOKEN|API_KEY|DSN)$/i', $key) === 1;
+    }
+}
 ```
 
 You can also override services used internally, for example if you need to specify options for the BlueScreen instance, you can provide custom instance with an [alias](http://symfony.com/doc/current/components/dependency_injection/advanced.html#aliasing):

--- a/src/BlueScreen/BlueScreenFactory.php
+++ b/src/BlueScreen/BlueScreenFactory.php
@@ -11,11 +11,18 @@ use function array_merge;
 
 final class BlueScreenFactory
 {
-    /** @param string[] $collapsePaths */
-    public static function create(array $collapsePaths): BlueScreen
+    /**
+     * @param string[] $collapsePaths
+     * @param (callable(string, mixed, string|null): bool)|null $scrubber
+     */
+    public static function create(array $collapsePaths, callable|null $scrubber = null): BlueScreen
     {
         $blueScreen = Debugger::getBlueScreen();
         $blueScreen->collapsePaths = array_merge($blueScreen->collapsePaths, $collapsePaths);
+
+        if ($scrubber !== null) {
+            $blueScreen->scrubber = $scrubber;
+        }
 
         return $blueScreen;
     }

--- a/src/BlueScreen/TracyScrubber.php
+++ b/src/BlueScreen/TracyScrubber.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cdn77\TracyBlueScreenBundle\BlueScreen;
+
+interface TracyScrubber
+{
+    public function __invoke(string $key, mixed $value, string|null $class): bool;
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -19,6 +19,7 @@ final class Configuration implements ConfigurationInterface
     public const string ParameterConsoleLogDirectory = 'log_directory';
     public const string ParameterControllerEnabled = 'enabled';
     public const string ParameterControllerListenerPriority = 'listener_priority';
+    public const string ParameterScrubber = 'scrubber';
 
     public const string SectionBlueScreen = 'blue_screen';
     public const string SectionConsole = 'console';
@@ -93,6 +94,12 @@ final class Configuration implements ConfigurationInterface
                                 '%kernel.project_dir%/bootstrap.php.cache',
                                 '%kernel.cache_dir%',
                             ])
+                            ->end()
+                        ->stringNode(self::ParameterScrubber)
+                            //phpcs:ignore SlevomatCodingStandard.Files.LineLength.LineTooLong
+                            ->info('Service ID of a callable(string $key, mixed $value, ?string $class): bool that returns true for sensitive data to hide.')
+                            ->cannotBeEmpty()
+                            ->defaultNull()
                             ->end()
                         ->end()
                     ->end()

--- a/src/DependencyInjection/TracyBlueScreenExtension.php
+++ b/src/DependencyInjection/TracyBlueScreenExtension.php
@@ -7,6 +7,7 @@ namespace Cdn77\TracyBlueScreenBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 
 use function assert;
@@ -72,6 +73,12 @@ final class TracyBlueScreenExtension extends ConfigurableExtension
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/config'));
         $loader->load('services.yml');
+
+        $scrubberServiceId = $blueScreenConfig[Configuration::ParameterScrubber];
+        if ($scrubberServiceId !== null) {
+            $container->getDefinition('cdn77.tracy_blue_screen.tracy.blue_screen.default')
+                ->setArgument('$scrubber', new Reference($scrubberServiceId));
+        }
 
         $environment = $container->getParameter('kernel.environment');
         assert(is_string($environment));

--- a/tests/DependencyInjection/TracyBlueScreenExtensionTest.php
+++ b/tests/DependencyInjection/TracyBlueScreenExtensionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cdn77\TracyBlueScreenBundle\Tests\DependencyInjection;
 
+use Cdn77\TracyBlueScreenBundle\BlueScreen\TracyScrubber;
 use Cdn77\TracyBlueScreenBundle\DependencyInjection\TracyBlueScreenExtension;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -141,6 +142,41 @@ final class TracyBlueScreenExtensionTest extends AbstractExtensionTestCase
         $collapsePaths = $this->container->getParameter('cdn77.tracy_blue_screen.blue_screen.collapse_paths');
 
         self::assertEmpty($collapsePaths);
+    }
+
+    public function testScrubberIsNullByDefault(): void
+    {
+        $this->loadExtensions();
+
+        $blueScreen = $this->container->get('cdn77.tracy_blue_screen.tracy.blue_screen.default');
+        assert($blueScreen instanceof BlueScreen);
+
+        self::assertNull($blueScreen->scrubber);
+    }
+
+    public function testSetScrubber(): void
+    {
+        $scrubber = new class implements TracyScrubber {
+            public function __invoke(string $key, mixed $value, string|null $class): bool
+            {
+                return $key === 'secret';
+            }
+        };
+
+        $this->container->set('my_scrubber', $scrubber);
+
+        $this->loadExtensions(
+            [
+                'tracy_blue_screen' => [
+                    'blue_screen' => ['scrubber' => 'my_scrubber'],
+                ],
+            ],
+        );
+
+        $blueScreen = $this->container->get('cdn77.tracy_blue_screen.tracy.blue_screen.default');
+        assert($blueScreen instanceof BlueScreen);
+
+        self::assertSame($scrubber, $blueScreen->scrubber);
     }
 
     /** @return ExtensionInterface[] */


### PR DESCRIPTION
## Summary
- Adds optional `scrubber` callable to `BlueScreenFactory` for masking sensitive values
- Configure via `tracy_blue_screen.blue_screen.scrubber` with a service ID
- Includes `TracyScrubber` interface for type safety

## Usage
```yaml
tracy_blue_screen:
  blue_screen:
    scrubber: App\Tracy\MyScrubber
```

The scrubber is a `callable(string $key, mixed $value, ?string $class): bool` that returns `true` for values that should be hidden.