### PR TITLE
chore(deps): require tracy ^2.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		"symfony/dependency-injection": "^7.4 || ^8",
 		"symfony/http-kernel": "^7.4 || ^8",
 		"symfony/yaml": "^7.4 || ^8",
-		"tracy/tracy": "^2.8"
+		"tracy/tracy": "^2.11"
 	},
 	"require-dev": {
 		"cdn77/coding-standard": "^7.0",


### PR DESCRIPTION
## Summary

- Bump minimum Tracy version from ^2.8 to ^2.11
- Tracy 2.11 added scrubber support which this bundle now uses