### PR TITLE
fix: use correct kernel.project_dir parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ tracy_blue_screen:
         # Add paths which should be collapsed (for external/compiled code) so that actual error is expanded.
         collapse_paths:
             # Defaults:
-            - '%kernel.project%/bootstrap.php.cache'
+            - '%kernel.project_dir%/bootstrap.php.cache'
             - '%kernel.cache_dir%'
             # plus paths set in BlueScreen instance used (/vendor)
 


### PR DESCRIPTION
## Summary

- Fix typo in README configuration example: `%kernel.project%` → `%kernel.project_dir%`
- The correct Symfony parameter name is `kernel.project_dir`