### PR TITLE
refactor: use named argument for collapsePaths in service config

### DIFF
--- a/src/DependencyInjection/config/services.yml
+++ b/src/DependencyInjection/config/services.yml
@@ -5,7 +5,7 @@ services:
         class: Tracy\BlueScreen
         factory: [Cdn77\TracyBlueScreenBundle\BlueScreen\BlueScreenFactory, create]
         arguments:
-            - '%cdn77.tracy_blue_screen.blue_screen.collapse_paths%'
+            $collapsePaths: '%cdn77.tracy_blue_screen.blue_screen.collapse_paths%'
         public: false
 
     cdn77.tracy_blue_screen.tracy.logger: '@cdn77.tracy_blue_screen.tracy.logger.default'


### PR DESCRIPTION
## Summary

- Use named argument `$collapsePaths` instead of positional argument in services.yml
- Prepares for adding more arguments to `BlueScreenFactory::create()`